### PR TITLE
Add new action to copy all open tabs to the clipboard

### DIFF
--- a/src/main/kotlin/com/github/mwguerra/copyfilecontent/CopyAllOpenTabsAction.kt
+++ b/src/main/kotlin/com/github/mwguerra/copyfilecontent/CopyAllOpenTabsAction.kt
@@ -1,0 +1,26 @@
+package com.github.mwguerra.copyfilecontent
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.fileEditor.FileEditorManager
+
+class CopyAllOpenTabsAction : AnAction() {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+
+        // Gather all open files (open tabs) in the current project
+        val openFiles = FileEditorManager.getInstance(project).openFiles
+        if (openFiles.isEmpty()) {
+            CopyFileContentAction.showNotification(
+                "No open tabs found to copy.",
+                com.intellij.notification.NotificationType.INFORMATION,
+                project
+            )
+            return
+        }
+
+        // Reuse the existing CopyFileContentAction but bypass its direct usage of CommonDataKeys
+        CopyFileContentAction().performCopyFilesContent(e, openFiles)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -59,5 +59,10 @@
                 description="Copy folder and file content to the clipboard.">
             <add-to-group group-id="CopyReferencePopupGroup" anchor="after" relative-to-action="CopyPaths"/>
         </action>
+        <action id="CopyAllOpenTabsAction"
+                class="com.github.mwguerra.copyfilecontent.CopyAllOpenTabsAction"
+                text="Copy All Open Tabs to Clipboard"
+                description="Copy the content of all open editor tabs to the clipboard.">
+        </action>
     </actions>
 </idea-plugin>


### PR DESCRIPTION
# Add New Action: Copy All Open Tabs to Clipboard

This merge request introduces a new action to the "Copy File Content" plugin that allows users to copy the contents of all currently open editor tabs to the clipboard. The new action, **Copy All Open Tabs to Clipboard**, is discoverable via the **Ctrl+Shift+A** (or **Cmd+Shift+A** on macOS) **Find Action** dialog.

## Key Changes

- **New File:**  
  `src/main/kotlin/com/github/mwguerra/copyfilecontent/CopyAllOpenTabsAction.kt`  
  - Implements an action that retrieves all open files from the editor using `FileEditorManager`.
  - Reuses the existing file copying logic by calling a helper method in `CopyFileContentAction`.

- **Updated File:**  
  `src/main/kotlin/com/github/mwguerra/copyfilecontent/CopyFileContentAction.kt`  
  - Refactored the original `actionPerformed` method to extract the file-copying logic into a helper method `performCopyFilesContent`.
  - The helper method accepts an array of `VirtualFile` objects so that it can be reused by both the original action (when files are selected) and the new "open tabs" action.
  - Added a `companion object` helper method `showNotification` so that both actions can display messages consistently.

- **Updated Plugin Descriptor:**  
  `src/main/resources/META-INF/plugin.xml`  
  - Registered the new action under `<actions>`, giving it a unique ID (`CopyAllOpenTabsAction`) and descriptive text.
  - This makes the new action searchable from the **Find Action** dialog.
